### PR TITLE
Fix extra } on @internal tag

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -1044,7 +1044,7 @@ the developers of this software.
 
 or inline:
 
-    {@internal [description]}}
+    {@internal [description]}
 
 The inline version of this tag may, contrary to other inline tags, contain
 text but also other inline tags. To increase readability and ease parsing
@@ -1084,7 +1084,7 @@ function count()
 /**
  * Counts the number of Foo.
  *
- * {@internal Silently adds one extra Foo to compensate for lack of Foo }}
+ * {@internal Silently adds one extra Foo to compensate for lack of Foo }
  *
  * @return int Indicates the number of items.
  */


### PR DESCRIPTION
It seems this is a typo rather than intended, otherwise the docs should be updated to reflect that inline }} is intended.