### PR TITLE
Tuple parameter type.

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -1966,13 +1966,14 @@ class Foo
 A Type has the following [ABNF][RFC5234] definition:
 
     type-expression  = type *("|" type)
-    type             = class-name / keyword / array
+    type             = class-name / keyword / array / tuple
     array            = (type / array-expression) "[]" / generic
     array-expression = "(" type-expression ")"
     generic          = collection-type "<" [type-expression "," *SP] type-expression ">"
     collection-type  = class-name / "array"
     class-name       = ["\"] label *("\" label)
     label            = (ALPHA / %x7F-FF) *(ALPHA / DIGIT / %x7F-FF)
+    tuple            = "tuple<" type-expression *( "," *SP type-expression) ">"
     keyword          = "array" / "bool" / "callable" / "false" / "float" / "int" / "mixed" / "null" / "object" /
     keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this"
 
@@ -2035,6 +2036,24 @@ The type of a value, or key, MAY consist of several different types, this can be
 individual type with a vertical bar sign between the angular brackets.
 
     @return \ArrayObject<string|bool>
+
+#### Tuples
+
+The value represented by "Type" can also be a [Tuple][TUPLE], a fixed-length array of values, where each value's type is
+explicitly defined. Tuples are specified using Generics-style notation.
+
+The number of types specified via Generics-style notation determines the length of the returned array, and at least one
+type MUST be defined. Additionally, the returned array MUST be sequential, as it will typically be consumed using the
+[list][PHP_LIST] operator.
+
+Example: to indicate that this element returns an array containing a string at index 0, an integer at index 1, and a
+boolean at index 2.
+
+    @return tuple<string,int,bool>
+
+Example: to indicate that this element returns an array containing three integers at indices 0, 1, and 2.
+
+    @return tuple<int,int,int>
 
 ### Valid Class Name
 
@@ -2202,6 +2221,7 @@ The following keywords are recognized by this PSR:
 [RFC5234]:      https://tools.ietf.org/html/rfc5234
 [RFC2396]:      https://tools.ietf.org/html/rfc2396
 [SEMVER2]:      http://www.semver.org
+[PHP_LIST]:     https://php.net/manual/function.list.php
 [PHP_SUBSTR]:   https://php.net/manual/function.substr.php
 [PHP_RESOURCE]: https://php.net/manual/language.types.resource.php
 [PHP_PSEUDO]:   https://php.net/manual/language.pseudo-types.php
@@ -2212,3 +2232,4 @@ The following keywords are recognized by this PSR:
 [PHPDOC.ORG]:   http://www.phpdoc.org/
 [FLUENT]:       https://en.wikipedia.org/wiki/Fluent_interface
 [COLLECTION]:   https://en.wikipedia.org/wiki/Collection_(abstract_data_type)
+[TUPLE]:        https://en.wikipedia.org/wiki/Tuple


### PR DESCRIPTION
This PR introduces a `tuple` type to the types appendix, inspired by [Typhax's tuple type syntax](https://github.com/eloquent/typhax#tuple).

Tuples are useful constructs that are formalized in many languages. They are essentially fixed-size arrays with specific types for each element. They are very useful in conjunction with the [list()](http://php.net/list) language construct:

``` php
$tuple = ['a', 1, true];             // type definition is tuple<string,int,bool>
list($string, $int, $bool) = $tuple; // unpacking the tuple using list()
```

As a side note, [Typhax](https://github.com/eloquent/typhax) is a project I wrote to define a more expressive type syntax for parameter documentation. It's probably only used by devs at the company I work for, and a few friends, but it's been very successful nonetheless.

 I'd like to open a few PRs to introduce ideas from Typhax, and generate some discussion. Hopefully I'm not too late to the game!
