### PR TITLE
Stringable parameter type.

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -1974,7 +1974,7 @@ A Type has the following [ABNF][RFC5234] definition:
     class-name       = ["\"] label *("\" label)
     label            = (ALPHA / %x7F-FF) *(ALPHA / DIGIT / %x7F-FF)
     keyword          = "array" / "bool" / "callable" / "false" / "float" / "int" / "mixed" / "null" / "object" /
-    keyword          = "resource" / "self" / "static" / "string" / "true" / "void" / "$this"
+    keyword          = "resource" / "self" / "static" / "string" / "stringable" / "true" / "void" / "$this"
 
 ### Details
 
@@ -2158,10 +2158,13 @@ The following keywords are recognized by this PSR:
 11. `callable`, the element to which this type applies is a pointer to a function call. This may be any type of callable
     as defined in the PHP manual about [pseudo-types][PHP_PSEUDO] or the section on [callable][PHP_CALLABLE].
 
-12. `false` or `true`, the element to which this type applies will have the value `TRUE` or `FALSE`. No other value will
+12. `stringable`, the element to which this type applies is either a `string`, `int`, `float`, or an `object` that has
+    a [__toString()][PHP_TOSTRING] method.
+
+13. `false` or `true`, the element to which this type applies will have the value `TRUE` or `FALSE`. No other value will
     be returned from this element.
 
-13. `self`, the element to which this type applies is of the same class as which the documented element is originally
+14. `self`, the element to which this type applies is of the same class as which the documented element is originally
     contained.
 
     **Example:**
@@ -2186,13 +2189,13 @@ The following keywords are recognized by this PSR:
     > of child classes with each representation of the class. This would make it obvious for the user which classes are
     > acceptable as type.
 
-14. `static`, the element to which this type applies is of the same class as which the documented element is contained,
+15. `static`, the element to which this type applies is of the same class as which the documented element is contained,
     or when encountered in a subclass is of type of that subclass instead of the original class.
 
     This keyword behaves the same way as the [keyword for late static binding][PHP_OOP5LSB] (not the static method,
     property, nor variable modifier) as defined by PHP.
 
-15. `$this`, the element to which this type applies is the same exact instance as the current class in the given
+16. `$this`, the element to which this type applies is the same exact instance as the current class in the given
     context. As such this type is a stricter version of `static` as, in addition, the returned instance must not only be
     of the same class but also the same instance.
 
@@ -2207,6 +2210,7 @@ The following keywords are recognized by this PSR:
 [PHP_PSEUDO]:   https://php.net/manual/language.pseudo-types.php
 [PHP_CALLABLE]: https://php.net/manual/language.types.callable.php
 [PHP_OOP5LSB]:  https://php.net/manual/language.oop5.late-static-bindings.php
+[PHP_TOSTRING]: https://php.net/manual/language.oop5.magic.php#object.tostring
 [SPDX]:         https://www.spdx.org/licenses
 [DEFACTO]:      http://www.phpdoc.org/docs/latest/index.html
 [PHPDOC.ORG]:   http://www.phpdoc.org/


### PR DESCRIPTION
This PR introduces a `stringable` type to the types appendix, inspired by [Typhax's stringable type syntax](https://github.com/eloquent/typhax#stringable).

The `stringable` type is designed to facilitate the situation in which only the string representation of value will be used, but the exact type of the value is irrelevant.

The exact types that are considered 'stringable' is probably a matter for discussion. Here I've simply followed Typhax's type definition, having strings, integers, floats, and objects that implement `__toString()`.

All of the string values of these types are definitely 'worthwhile'. I would argue that the string values of booleans, resources, and arrays are pretty useless. Null is excluded because it's more flexible to be able to choose between `stringable` and `stringable|null`.

The other approach, of course, would be to have `stringable` simply represent any value for which `strval($value)` does not result in a warning or error.
