### PR TITLE
Loosen end of summary sentence.

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -304,7 +304,7 @@ but not more than that.
 
 A Summary MUST end with either
 
-* a full stop (.) followed by a line break
+* an end of sentence ('.。!?¡¿！？') and followed by a line break;
 * or two sequential line breaks.
 
 If a Description is provided, then it MUST be preceded by a Summary. Otherwise


### PR DESCRIPTION
IMHO there is no real need to define how the `summary` must end, i.e. it must be a dot. So why not loosen it up? :)