### PR TITLE
Fixed another typo

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -245,7 +245,7 @@ interpreted as described in [RFC 2119][RFC2119].
   > file. 
   >
   > To prevent ambiguity when a Structural Element comes directly after a
-  > File-level DocBlock MUST that element have its own DocBlock in 
+  > File-level DocBlock that element MUST have it's own DocBlock in 
   > addition to the File-level DocBlock.
   >
   > Example of a valid File-level DocBlock:


### PR DESCRIPTION
`File-level DocBlock MUST that element have its own DocBlock` -> `File-level DocBlock that element MUST have it's own DocBlock`