### PR TITLE
property-read/write variants

### DIFF
--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -843,43 +843,50 @@ public function __construct(array $options = array())
 
 ### 5.14. @property
 
-The @property tag allows a class to know which 'magic' properties are present.
+The `@property` tag is used to declare which "magic" properties are supported.
 
 #### Syntax
 
-    @property ["Type"] [name] [<description>]
+    @property[<-read|-write>] ["Type"] [name] [<description>]
 
 #### Description
 
-The @property tag is used in the situation where a class contains the
-`__get()` and `__set()` magic methods and allows for specific names.
+The `@property` tag is used when a `class` (or `trait`) implements the `__get()`
+and/or `__set()` "magic" methods to resolve non-literal properties at run-time.
 
-An example of this is a child class whose parent has a `__get()`. The child
-knows which properties need to be present but relies on the parent class to use the
-`__get()` method to provide it.
-In this situation, the child class would have a @property tag for each magic
-property.
+The `@property-read` and `@property-write` variants MAY be used to indicate "magic"
+properties that can only be read or written.
 
-@property tags MUST NOT be used in a "PHPDoc" that is not associated with
-a *class* or *interface*.
+The `@property` tags MAY ONLY be used in a "PHPDoc" that is not associated with
+a *class*, *trait* or *interface*.
 
-#### Examples
+#### Example
+
+In the following example, a class `User` implements the magic `__get()` method, in
+order to implement a "magic", read-only `$full_name` property:
 
 ```php
-class Parent
-{
-    public function __get()
-    {
-        <...>
-    }
-}
-
 /**
- * @property string $myProperty
+ * @property-read string $full_name
  */
-class Child extends Parent
+class User
 {
-    <...>
+    /**
+     * @var string
+     */
+    public $first_name;
+    
+    /**
+     * @var string
+     */
+    public $last_name;
+
+    public function __get($name)
+    {
+        if ($name === "full_name") {
+            return "{$this->first_name} {$this->last_name}";
+        }
+    }
 }
 ```
 

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -857,8 +857,8 @@ and/or `__set()` "magic" methods to resolve non-literal properties at run-time.
 The `@property-read` and `@property-write` variants MAY be used to indicate "magic"
 properties that can only be read or written.
 
-The `@property` tags MAY ONLY be used in a "PHPDoc" associated with a *class*
-or *trait*.
+The `@property` tags MAY ONLY be used in a "PHPDoc" associated with a `class`
+or `trait`.
 
 #### Example
 

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -857,8 +857,8 @@ and/or `__set()` "magic" methods to resolve non-literal properties at run-time.
 The `@property-read` and `@property-write` variants MAY be used to indicate "magic"
 properties that can only be read or written.
 
-The `@property` tags MAY ONLY be used in a "PHPDoc" that is not associated with
-a *class*, *trait* or *interface*.
+The `@property` tags MAY ONLY be used in a "PHPDoc" associated with a *class*
+or *trait*.
 
 #### Example
 


### PR DESCRIPTION
Adds descriptions of the `@property-read` and `@property-write` variants.

Replaces the example with a simpler, more typical example.

QA: I'm uncertain as to why property-annotations were originally listed as being applicable to interfaces? An interface can't implement anything, so how could it implement properties? Interfaces can't have properties in PHP in the first place. I'd like to hear your thoughts on this?

If approved, this voids #90.
