### PR TITLE
revert deprecation of link tag

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -852,6 +852,9 @@ one space; multiple spaces MAY be used for readabiliy purpose. This includes all
 [string concatenation][], [type][] operators, trait operators (`insteadof` and `as`),
 and the single pipe operator (e.g. `ExceptionType1 | ExceptionType2 $e`).
 
+There MUST NOT be any whitespace between the increment/decrement operators and the variable 
+being incremented/decremented.
+
 Other operators are left undefined.
 
 For example:

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -887,6 +887,10 @@ comma, and there MUST be one space after each comma.
 Closure arguments with default values MUST go at the end of the argument
 list.
 
+If a return type is present, it MUST follow the same rules as with normal
+functions and methods; if the `use` keyword is present, the colon MUST follow
+the `use` list closing parentheses with no spaces between the two characters.
+
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
@@ -898,6 +902,10 @@ $closureWithArgs = function ($arg1, $arg2) {
 };
 
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+    // body
+};
+
+$closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
     // body
 };
 ~~~

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -23,7 +23,7 @@ PSR-19: PHPDoc tags
   - [5.7.  @global](#57-global)
   - [5.8.  @internal](#58-internal)
   - [5.9.  @license](#59-license)
-  - [5.10. @link [deprecated]](#510-link-deprecated)
+  - [5.10. @link ](#510-link)
   - [5.11. @method](#511-method)
   - [5.12. @package](#512-package)
   - [5.13. @param](#513-param)
@@ -630,10 +630,7 @@ license.
  */
 ```
 
-### 5.10. @link [deprecated]
-
-*This tag is deprecated in favor of the `@see` tag, which since this
-specification may relate to URIs.*
+### 5.10. @link
 
 The @link tag indicates a custom relation between the associated
 "Structural Element" and a website, which is identified by an absolute URI.


### PR DESCRIPTION
(decision **was** previously made to revert this deprecation (https://github.com/phpDocumentor/fig-standards/issues/104#issuecomment-138111143)
(replaces PR #136)