### PR TITLE
deprecate double closing brace on inline internal tag

### DIFF
--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -852,6 +852,9 @@ one space; multiple spaces MAY be used for readabiliy purpose. This includes all
 [string concatenation][], [type][] operators, trait operators (`insteadof` and `as`),
 and the single pipe operator (e.g. `ExceptionType1 | ExceptionType2 $e`).
 
+There MUST NOT be any whitespace between the increment/decrement operators and the variable 
+being incremented/decremented.
+
 Other operators are left undefined.
 
 For example:

--- a/proposed/extended-coding-style-guide.md
+++ b/proposed/extended-coding-style-guide.md
@@ -887,6 +887,10 @@ comma, and there MUST be one space after each comma.
 Closure arguments with default values MUST go at the end of the argument
 list.
 
+If a return type is present, it MUST follow the same rules as with normal
+functions and methods; if the `use` keyword is present, the colon MUST follow
+the `use` list closing parentheses with no spaces between the two characters.
+
 A closure declaration looks like the following. Note the placement of
 parentheses, commas, spaces, and braces:
 
@@ -898,6 +902,10 @@ $closureWithArgs = function ($arg1, $arg2) {
 };
 
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+    // body
+};
+
+$closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
     // body
 };
 ~~~

--- a/proposed/phpdoc-tags.md
+++ b/proposed/phpdoc-tags.md
@@ -540,12 +540,19 @@ the developers of this software.
 
 or inline:
 
+    {@internal [description]}
+
+Contrary to other inline tags, the inline version of this tag may also contain
+other inline tags (see example below).
+
+Implementations SHOULD support two closing braces for the inline version,
+due to [historical definition of the inline tag][INLINE_OLD] originally being:
+
     {@internal [description]}}
 
-The inline version of this tag may, contrary to other inline tags, contain
-text but also other inline tags. To increase readability and ease parsing
-the tag should be terminated with a double closing brace, instead of a single
-one.
+They MAY notify users that the two braces grammar is deprecated in favor
+of using just one closing brace, since parsers/IDEs are now better at
+recognizing matching pairs of open/close braces.
 
 #### Description
 
@@ -580,7 +587,7 @@ function count()
 /**
  * Counts the number of Foo.
  *
- * {@internal Silently adds one extra Foo to compensate for lack of Foo }}
+ * {@internal Silently adds one extra Foo (see {@link http://example.com})}
  *
  * @return int Indicates the number of items.
  */
@@ -1356,4 +1363,5 @@ class Foo
 [SEMVER2]:      http://www.semver.org
 [PHP_SUBSTR]:   https://php.net/manual/function.substr.php
 [SPDX]:         https://www.spdx.org/licenses
+[INLINE_OLD]:   https://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_tags.inlineinternal.pkg.html
 [PHPDOC_PSR]:   https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md


### PR DESCRIPTION
(replaces PR #135)