### PR TITLE
[PSR-17] Amendment: stream/resource pointer state

### DIFF
--- a/accepted/PSR-17-http-factory-meta.md
+++ b/accepted/PSR-17-http-factory-meta.md
@@ -268,6 +268,28 @@ the time this proposal was developed allowed a string URI when creating a
 `UriInterface` implementation they provided. As such, accepting a string is
 expedient and follows existing semantics.
 
+### 5.7 Why are Streams created with the read/write pointer at the beginning?
+
+The primary use case of `StreamFactoryInterface::createStream()` and
+`StreamFactoryInterface::createStreamFromFile()` is to create streams for the
+body of a `ResponseInterface` instance to be emitted as an HTTP response.
+
+An emitter can make no assumptions about streams (or their internal resource
+handles) being repeatable, and therefore can't simply `rewind()` the stream.
+
+Even in the case where a stream returns `true` for `isSeekable()`, rewinding
+the stream could have unacceptable performance implications. Similarly, the
+`__toString()` method results in unacceptable memory overhead for large streams.
+
+Consequently, to efficiently emit the body stream of a `ResponseInterface`
+instance as body of an HTTP response, we must be able to make an assumption
+about the stream pointer being positioned at the beginning of the stream.
+
+As for `StreamFactoryInterface::createStreamFromResource()`, the caller is
+responsible for the creation of the PHP resource to use as the basis for the
+stream, and therefore also assumes responsibility for the read/write pointer
+state of the resource and resulting stream.
+
 ## 6. People
 
 This PSR was produced by a FIG Working Group with the following members:

--- a/accepted/PSR-17-http-factory.md
+++ b/accepted/PSR-17-http-factory.md
@@ -117,6 +117,9 @@ interface StreamFactoryInterface
      * Create a new stream from a string.
      *
      * The stream SHOULD be created with a temporary resource.
+     * 
+     * The stream MUST be created with the current position of the file read/write
+     * pointer at the beginning of the stream.
      *
      * @param string $content String content with which to populate the stream.
      */
@@ -130,6 +133,9 @@ interface StreamFactoryInterface
      *
      * The `$filename` MAY be any string supported by `fopen()`.
      *
+     * The stream MUST be created with the current position of the file read/write
+     * pointer at the beginning of the stream.
+     *
      * @param string $filename The filename or stream URI to use as basis of stream.
      * @param string $mode The mode with which to open the underlying filename/stream.
      *
@@ -142,6 +148,8 @@ interface StreamFactoryInterface
      * Create a new stream from an existing resource.
      *
      * The stream MUST be readable and may be writable.
+     *
+     * The current read/write position of the given PHP resource MUST NOT be modified.
      *
      * @param resource $resource The PHP resource to use as the basis for the stream.
      */

--- a/proposed/event-dispatcher-meta.md
+++ b/proposed/event-dispatcher-meta.md
@@ -98,6 +98,23 @@ foreach ($provider->getListenersForEvent($event) as $listener) {
     
     if (! $returnedEvent instanceof $event) {
         // This is an exceptional case!
+        // 
+        // We now have an event of a different type, or perhaps nothing was
+        // returned by the listener. An event of a different type might mean:
+        // 
+        // - we need to trigger the new event
+        // - we have an event mismatch, and should raise an exception
+        // - we should attempt to trigger the remaining listeners anyway
+        // 
+        // In the case of nothing being returned, this could mean any of:
+        // 
+        // - we should continue triggering, using the original event
+        // - we should stop triggering, and treat this as a request to
+        //   stop propagation
+        // - we should raise an exception, because the listener did not
+        //   return what was expected
+        //
+        // In short, this becomes very hard to specify, or enforce.
     }
 
     if ($returnedEvent instanceof StoppableEventInterface

--- a/proposed/event-dispatcher-meta.md
+++ b/proposed/event-dispatcher-meta.md
@@ -152,7 +152,21 @@ It is even possible, and potentially advisable, to allow libraries to include th
 
 While combining the Dispatcher and Provider into a single object is a valid and permissible degenerate case, it is NOT RECOMMENDED as it reduces the flexibility of system integrators.  Instead, the provider SHOULD be composed as a dependent object.
 
-### 4.5 Return values
+### 4.5 Deferred listeners
+
+The specification requires that the callables returned by a Provider MUST all be invoked (unless propagation is explicitly stopped) before the Dispatcher returns.  However, the specification also explicitly states that Listeners may enqueue events for later processing rather than taking immediate action.  It is also entirely permissible for a Provider to accept registration of a callable, but then wrap it in another callable before returning it to the Dispatcher.  (In that case, the wrapper is the Listener from the Dispatcher's point of view.)  That allows all of the following behaviors to be legal:
+
+* Providers return callable listeners that were provided to them.
+* Providers return callables that create an entry in a queue that will react to the event with another callable at some later point in time.
+* Listeners may themselves create an entry in a queue that will react to the event at some later point in time.
+* Listeners or Providers may trigger an asynchronous task, if running in an environment with support for asynchronous behavior (assuming that the result of the asynchronous task is not needed by the Emitter.)
+* Providers may perform such delay or wrapping on Listeners selectively based on arbitrary logic.
+
+The net result is that Providers and Listeners are responsible for determining when it is safe to defer a response to an Event until some later time.  In that case, the Provider or Listener is explicitly opting out of being able to pass meaningful data back to the Emitter, but the Working Group determined that they were in the best position to know if it was safe to do so.
+
+While technically a side effect of the design, it is essentially the same approach used by Laravel (as of Laravel 5) and has been proven in the wild.
+
+### 4.6 Return values
 
 Per the spec, a Dispatcher MUST return the event it was passed to the Emitter.  That is done to provide a more ergonomic experience for users.  That is, it allows short-hands similar to the following:
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -69,7 +69,7 @@ A Dispatcher
 
 If passed a Stoppable Event, a Dispatcher
 
-* MUST call `isPropagationStopped()` on the Event after each Listener has been called.  If that method returns `true` it MUST return the Event to the Emitter immediately and MUST NOT call any further Listeners.
+* MUST call `isPropagationStopped()` on the Event before each Listener has been called.  If that method returns `true` it MUST return the Event to the Emitter immediately and MUST NOT call any further Listeners.  That is, if an Event is passed to the Dispatcher that always returns `true` from `isPropagationStopped()`, zero listeners will be called.
 
 ### Error handling
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -65,7 +65,7 @@ A Dispatcher
 * MUST call Listeners synchronously in the order they are returned from a ListenerProvider.
 * MUST return the same Event object it was passed after it is done invoking Listeners.
 * MUST NOT return to the Emitter until all Listeners have executed.
-* As an exception to the previous point, if the Event is a Promise object then the the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
+* As an exception to the previous point, if the Event is a [Promise object](https://promisesaplus.com/) then the the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
 
 If passed a Stoppable Event, a Dispatcher
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -67,7 +67,7 @@ A Dispatcher
 * MUST call Listeners synchronously in the order they are returned from a ListenerProvider.
 * MUST return the same Event object it was passed after it is done invoking Listeners.
 * MUST NOT return to the Emitter until all Listeners have executed.
-* As an exception to the previous point, if the Event is a [Promise object](https://promisesaplus.com/) then the the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
+* As an exception to the previous point, if the Event is a [Promise object](https://promisesaplus.com/) then the Dispatcher MAY return that Promise before all Listeners have executed.  However, the Promise MUST NOT be treated as fulfilled until all Listeners have executed.
 
 If passed a Stoppable Event, a Dispatcher
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -54,9 +54,7 @@ A Listener MUST have a `void` return, and SHOULD type hint that return explicitl
 
 A Listener MAY delegate actions to other code.  That includes a Listener being a thin wrapper around retrieving an object from a service container that contains the actual business logic to run, or other similar forms of indirection.  In that case the callable containing the actual business logic SHOULD conform to the same rules as if it were called directly as a Listener.
 
-A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so, however, care should be taken that not all Event objects may be safely serializable.
-
-A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.  Additionally, the `isPropagationStopped()` method will not be called in this case and thus the Event is effectively unstoppable.
+A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so, however, care should be taken that not all Event objects may be safely serializable. A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.  Additionally, the `isPropagationStopped()` method will not be called in this case and thus the Event is effectively unstoppable.
 
 ## Dispatcher
 

--- a/proposed/event-dispatcher.md
+++ b/proposed/event-dispatcher.md
@@ -56,6 +56,8 @@ A Listener MAY delegate actions to other code.  That includes a Listener being a
 
 A Listener MAY enqueue information from the Event for later processing by a secondary process, using cron, a queue server, or similar techniques.  It MAY serialize the Event object itself to do so, however, care should be taken that not all Event objects may be safely serializable.
 
+A secondary process MUST assume that any changes it makes to an Event object will NOT propagate to other Listeners.  Additionally, the `isPropagationStopped()` method will not be called in this case and thus the Event is effectively unstoppable.
+
 ## Dispatcher
 
 A Dispatcher is a service object implementing `EventDispatcherInterface`.  It is responsible for invoking listeners provided by a Listener Provider on an Event.


### PR DESCRIPTION
I am proposing the following amendment to PSR-17.

I am aware of the [amendments clause of the bylaws](https://www.php-fig.org/bylaws/psr-amendments/):

> Following the rules of the workflow bylaw, once a PSR has been “Accepted” the PSR meaning cannot change, backwards compatibility must remain at 100%, and any confusion that arises from original wording can be clarified through errata.
> 
> The rules for errata are covered in the workflow bylaw, and only allow non-backwards compatible clarification to be added to the meta document. Sometimes, modifications will be necessary in PSR document itself, and this document outlines those cases.

The question here is what exactly is implied by "backwards compatibility".

In the usual sense of "backwards compatibility" with regards to a class, for example, the addition of a new feature (such as a new method or optional argument) maintains "backwards compatibility", in the sense that it doesn't *change* something that already exists.

In the same sense, the omission of this important detail in the specification doesn't *change* something that already exists, but rather adds something that was missing and thereby addresses a problem with the existing specification.

While this will render some existing implementations "buggy", these were already "buggy", in the sense that they can't actually be used with existing emitters or with predictable results, as per the circumstances described in proposed section 5.7 of `PSR-17-http-factory-meta.md`.

---

The issue was debated on the forum here:

https://groups.google.com/forum/#!topic/php-fig/S5YIw-Pu1yM
