### PR TITLE
Add link to "PHPDoc tags" in phpdoc.md

### DIFF
--- a/proposed/phpdoc.md
+++ b/proposed/phpdoc.md
@@ -669,4 +669,4 @@ The following keywords are recognized by this PSR:
 [DEFACTO]:      http://www.phpdoc.org/docs/latest/index.html
 [PHPDOC.ORG]:   http://www.phpdoc.org/
 [FLUENT]:       https://en.wikipedia.org/wiki/Fluent_interface
-[TAG_PSR]:      TBD
+[TAG_PSR]:      phpdoc-tags.md


### PR DESCRIPTION
Currently, tag-related links point to “TBD” (which resolves to a 404 page) instead of the PSR-19 page. This change simply replaces “TBD” with “phpdoc-tags.md”.